### PR TITLE
fix: explicitly import `params` from `Flux`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AtomicGraphNets"
 uuid = "ccdf130a-3c88-4595-a023-a7e7f78b9dd5"
 authors = ["Rachel Kurchin <rkurchin@cmu.edu>"]
-version = "0.2.3"
+version = "0.2.4"
 
 [deps]
 AtomGraphs = "5a360db7-3336-4c46-b5a1-be4fe079ea55"

--- a/examples/1_formation_energy/formation_energy.jl
+++ b/examples/1_formation_energy/formation_energy.jl
@@ -97,7 +97,7 @@ function train_formation_energy(;
     end
     @epochs num_epochs Flux.train!(
         loss,
-        params(model),
+        Flux.params(model),
         train_data,
         opt,
         cb = Flux.throttle(evalcb, 5),

--- a/test/model_tests.jl
+++ b/test/model_tests.jl
@@ -49,7 +49,7 @@ input = featurize(ag, dummyfzn)
         loss(x, y) = Flux.Losses.mse(model(x), y)
         data = zip([input], [1.0]) # high-quality data...
         opt = Descent(0.1) # should be deterministic
-        Flux.train!(loss, params(model), data, opt)
+        Flux.train!(loss, Flux.params(model), data, opt)
         @test model(input)[1] ≈ 1.051 atol = 1e-3
     end
 end
@@ -72,7 +72,7 @@ end
         loss(x, y) = Flux.Losses.mse(model(x), y)
         data = zip([(input, input)], [1.0]) # high-quality data...
         opt = Descent(0.1) # should be deterministic
-        Flux.train!(loss, params(model), data, opt)
+        Flux.train!(loss, Flux.params(model), data, opt)
         @test model((input, input))[1] ≈ -75.985 atol = 1e-3
     end
 end
@@ -105,7 +105,7 @@ end
         loss(x, y) = Flux.Losses.mse(model(x), y)
         data = zip([input], [1.0]) # high-quality data...
         opt = Descent(0.1) # should be deterministic
-        Flux.train!(loss, params(model), data, opt)
+        Flux.train!(loss, Flux.params(model), data, opt)
         @test model(input)[1] ≈ 1.051563 atol = 1e-6
     end
 end


### PR DESCRIPTION
As of `0.13.0`, `Flux` doesn't export `params` anymore, as a result
of which tests will error out if we update the compat for `Flux` to
include `0.13` as well.
Thus, explicitly import `params` from `Flux`.

Signed-off-by: Anant Thazhemadam <anant.thazhemadam@gmail.com>